### PR TITLE
Add multiple IDP support to example setup

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -66,6 +66,9 @@ logs-proxy: ## Show logs from SAML proxy only
 logs-idp: ## Show logs from Keycloak IdP only
 	@docker-compose logs -f keycloak-idp
 
+logs-idp2: ## Show logs from Keycloak IdP2 only
+	@docker-compose logs -f keycloak-idp2
+
 logs-sp: ## Show logs from Keycloak SP only
 	@docker-compose logs -f keycloak-sp
 
@@ -74,6 +77,9 @@ shell-proxy: ## Get shell access to SAML proxy container
 
 shell-idp: ## Get shell access to Keycloak IdP container
 	@docker-compose exec keycloak-idp bash
+
+shell-idp2: ## Get shell access to Keycloak IdP2 container
+	@docker-compose exec keycloak-idp2 bash
 
 shell-sp: ## Get shell access to Keycloak SP container
 	@docker-compose exec keycloak-sp bash

--- a/example/README.md
+++ b/example/README.md
@@ -4,11 +4,12 @@ This directory contains the integration testing setup for the Simple SAML Proxy 
 
 ## Architecture
 
-The integration testing environment uses a **Keycloak + Keycloak** setup:
+The integration testing environment uses a **Multi-Keycloak** setup to test the proxy's IDP selection functionality:
 
-- **Keycloak IdP** (port 8080): Acts as the Identity Provider with test users
+- **Keycloak IdP** (port 8080): Acts as the first Identity Provider ("Development IdP") with test users
+- **Keycloak IdP2** (port 8083): Acts as the second Identity Provider ("Enterprise IdP") with enterprise users
 - **Keycloak SP** (port 8081): Acts as the Service Provider consuming authentication
-- **Simple SAML Proxy** (port 8082): The proxy being tested, bridges IdP and SP
+- **Simple SAML Proxy** (port 8082): The proxy being tested, bridges multiple IDPs and SP
 
 ## Quick Start
 
@@ -33,11 +34,30 @@ make test       # Run integration tests
 ### Access Points
 
 - **Keycloak IdP Admin**: http://localhost:8080/admin (admin/admin)
+- **Keycloak IdP2 Admin**: http://localhost:8083/admin (admin/admin)
 - **Keycloak SP Admin**: http://localhost:8081/admin (admin/admin)
 - **SAML Proxy**: http://localhost:8082
-- **Test User**: testuser/testpassword
+
+### Test Users
+
+#### Development IdP (port 8080)
+- **testuser/testpassword** - Standard test user
+
+#### Enterprise IdP (port 8083)
+- **enterpriseuser/enterprisepassword** - Enterprise user
+- **testuser/testpassword** - Test user (IDP2 variant)
 
 ## Testing
+
+### IDP Selection Screen Testing
+
+With the multi-IDP setup, you can now test the proxy's IDP selection functionality:
+
+1. **Start the environment**: `make dev-setup`
+2. **Access Keycloak SP**: http://localhost:8081
+3. **Initiate SAML login** through the SP's SAML broker
+4. **Observe IDP selection screen** at the proxy (should show "Development IdP" and "Enterprise IdP")
+5. **Test different IDPs** by selecting each option and logging in with respective users
 
 ### End-to-End Tests (Playwright)
 
@@ -119,9 +139,14 @@ PROXY_ENTITY_ID: "http://localhost:8082/metadata"
 PROXY_ACS_URL: "http://localhost:8082/acs"
 PROXY_SSO_URL: "http://localhost:8082/sso"
 
-# IdP configuration
+# IdP configuration (Multiple IDPs)
 IDP_0_ID: "keycloak-idp"
+IDP_0_NAME: "Development IdP"
 IDP_0_METADATA_URL: "http://keycloak-idp:8080/realms/test/protocol/saml/descriptor"
+
+IDP_1_ID: "keycloak-idp2"
+IDP_1_NAME: "Enterprise IdP"
+IDP_1_METADATA_URL: "http://keycloak-idp2:8083/realms/test2/protocol/saml/descriptor"
 
 # SP configuration
 PROXY_ALLOWED_SP_0_ENTITY_ID: "http://keycloak-sp:8080/realms/test"

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -41,6 +41,25 @@ services:
     volumes:
       - ./keycloak-idp:/opt/keycloak/data/import
 
+  # Keycloak as second Identity Provider
+  keycloak-idp2:
+    <<: *keycloak-common
+    container_name: keycloak-idp2
+    environment:
+      <<: *keycloak-env
+      KC_HOSTNAME_URL: "http://localhost:8083"
+      KC_HTTP_PORT: 8083
+    ports:
+      - "8083:8083"
+    volumes:
+      - ./keycloak-idp2:/opt/keycloak/data/import
+    command:
+      - start-dev
+      - --import-realm
+      - --hostname-strict=false
+      - --hostname-strict-https=false
+      - --http-port=8083
+
   # Keycloak as Service Provider  
   keycloak-sp:
     <<: *keycloak-common
@@ -77,9 +96,15 @@ services:
       
       # Identity Provider configuration (Keycloak IdP)
       IDP_0_ID: "keycloak-idp"
-      IDP_0_NAME: "Keycloak IdP"
+      IDP_0_NAME: "Development IdP"
       IDP_0_METADATA_URL: "http://keycloak-idp:8080/realms/test/protocol/saml/descriptor"
       IDP_0_SSO_URL: "http://keycloak-idp:8080/realms/test/protocol/saml"
+      
+      # Second Identity Provider configuration (Keycloak IdP2)
+      IDP_1_ID: "keycloak-idp2"
+      IDP_1_NAME: "Enterprise IdP"
+      IDP_1_METADATA_URL: "http://keycloak-idp2:8083/realms/test2/protocol/saml/descriptor"
+      IDP_1_SSO_URL: "http://keycloak-idp2:8083/realms/test2/protocol/saml"
       
       # Allowed Service Providers (Keycloak SP)
       PROXY_ALLOWED_SP_0_ENTITY_ID: "http://localhost:8081/realms/sp-realm"
@@ -104,6 +129,7 @@ services:
       - saml-network
     depends_on:
       - keycloak-idp
+      - keycloak-idp2
       - keycloak-sp
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/metadata"]

--- a/example/keycloak-idp2/test-realm.json
+++ b/example/keycloak-idp2/test-realm.json
@@ -1,0 +1,113 @@
+{
+  "realm": "test2",
+  "enabled": true,
+  "displayName": "Test IdP2 Realm (Enterprise)",
+  "accessTokenLifespan": 3600,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "attributes": {
+    "saml.issuer": "http://localhost:8083/realms/test2"
+  },
+  "users": [
+    {
+      "username": "enterpriseuser",
+      "enabled": true,
+      "email": "enterpriseuser@company.com",
+      "firstName": "Enterprise",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "enterprisepassword",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "testuser",
+      "enabled": true,
+      "email": "testuser@company.com",
+      "firstName": "Test",
+      "lastName": "User (IDP2)",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpassword",
+          "temporary": false
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "http://localhost:8082/saml/metadata",
+      "name": "SAML Proxy Client (crewjam)",
+      "enabled": true,
+      "protocol": "saml",
+      "frontchannelLogout": true,
+      "attributes": {
+        "saml.assertion.signature": "true",
+        "saml.force.post.binding": "true",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "true",
+        "saml.signature.algorithm": "RSA_SHA256",
+        "saml.client.signature": "false",
+        "saml.authnstatement": "true",
+        "display.on.consent.screen": "false"
+      },
+      "redirectUris": [
+        "http://localhost:8082/saml/acs"
+      ],
+      "baseUrl": "http://localhost:8082",
+      "adminUrl": "http://localhost:8082"
+    },
+    {
+      "clientId": "http://localhost:8082/metadata",
+      "name": "SAML Proxy Client (zitadel)",
+      "enabled": true,
+      "protocol": "saml",
+      "frontchannelLogout": true,
+      "attributes": {
+        "saml.assertion.signature": "true",
+        "saml.force.post.binding": "true",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "true",
+        "saml.signature.algorithm": "RSA_SHA256",
+        "saml.client.signature": "false",
+        "saml.authnstatement": "true",
+        "display.on.consent.screen": "false"
+      },
+      "redirectUris": [
+        "http://localhost:8082/metadata/acs"
+      ],
+      "baseUrl": "http://localhost:8082",
+      "adminUrl": "http://localhost:8082"
+    },
+    {
+      "clientId": "http://localhost:8082",
+      "name": "SAML Proxy Client (base)",
+      "enabled": true,
+      "protocol": "saml",
+      "frontchannelLogout": true,
+      "attributes": {
+        "saml.assertion.signature": "true",
+        "saml.force.post.binding": "true",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "true",
+        "saml.signature.algorithm": "RSA_SHA256",
+        "saml.client.signature": "false",
+        "saml.authnstatement": "true",
+        "display.on.consent.screen": "false"
+      },
+      "redirectUris": [
+        "http://localhost:8082/metadata/acs",
+        "http://localhost:8082/saml/acs"
+      ],
+      "baseUrl": "http://localhost:8082",
+      "adminUrl": "http://localhost:8082"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for multiple Identity Providers in the example setup to enable testing of the proxy's IDP selection screen functionality.

## Changes

- Add second Keycloak IDP (keycloak-idp2) on port 8083
- Create Enterprise IdP realm configuration with test users
- Update proxy to support both Development and Enterprise IDPs
- Add IDP selection screen testing documentation
- Update Makefile with commands for second IDP
- Configure distinct IDP names for clear selection identification

## Testing

To test the IDP selection functionality:
1. Run `make dev-setup`
2. Access Keycloak SP and initiate SAML login
3. Observe the proxy's IDP selection screen
4. Test both IDPs with their respective users

Closes #33

Generated with [Claude Code](https://claude.ai/code)